### PR TITLE
test(GX3-5676): Se añaden pruebas E2E para validar mensajes tras seleccionar los radio buttons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,14 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.pytestArgs": [
-        "--color=yes",
         "tests"
     ],
+
+
+    "python.defaultInterpreterPath": "/miniconda3/envs/picadita-selelium-python/python.exe",
+    "python.terminal.activateEnvironment": true,
+    "terminal.integrated.env.linux": {
+        "CONDA_DEFAULT_ENV": "picadita-selelium-python"
+    },
+
 }

--- a/tests/e2e/Elements/test_Elements_Button.py
+++ b/tests/e2e/Elements/test_Elements_Button.py
@@ -1,4 +1,4 @@
-from utils.imports import *
+from tests.e2e.utils.imports import *
 
 # Story GX3-5656
 class Test_Elements_Button:

--- a/tests/e2e/Elements/test_Elements_Radio_Buttons.py
+++ b/tests/e2e/Elements/test_Elements_Radio_Buttons.py
@@ -1,20 +1,44 @@
-from tests.Elements.utils.imports import *
+from tests.e2e.utils.imports import *
 
+# Story GX3-5676
+class Test_Elements_Radio_Buttons:
 
-class Test_GX3_5676_Elements_Radio_Buttons:
-    
     @pytest.fixture
     def web(self):
-        """Precondition: Open the demo page and wait for primary button visibility"""
+        """Precondition: open the demo page and wait for the class that stores the text to be seen - Do you like the site? -"""
         driver = Chrome()
         driver.get('https://demoqa.com/radio-button')
         WebDriverWait(driver, 20).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR, ".btn.btn-primary"))
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".mb-3"))
         )
-    
+
         yield driver
         driver.quit()
-    
-    def test_left_click(self, web):
-        """TC01: Validar que el mensaje "“You have selected Yes” se muestra correctamente cuando se selecciona el RB 'Yes'"""
-        pass
+
+    def test_should_display_message_by_selecting_yes_radio_button(self, web: WebDriver):
+        """TC01: Validate that the message "You have selected Yes" is displayed correctly after selecting the "Yes" radio button."""
+        label_for_yes_radio = web.find_element(By.CSS_SELECTOR, "label[for='yesRadio']")
+        label_for_yes_radio.click()
+        
+        message = web.find_element(By.CSS_SELECTOR, ".mt-3")
+        assert message.text == "You have selected Yes"
+
+    def test_should_display_message_by_selecting_impressive_radio_button(self, web: WebDriver):
+        """TC02: Validate that the message "You have selected Impressive" is displayed correctly after selecting the "Impressive" radio button."""
+        label_for_impressive_radio = web.find_element(By.CSS_SELECTOR, "label[for='impressiveRadio']")
+        label_for_impressive_radio.click()
+        
+        message = web.find_element(By.CSS_SELECTOR, ".mt-3")
+        assert message.text == "You have selected Impressive"    
+
+    def test_should_not_select_no_radio_button_with_cursor(self, web: WebDriver):
+        """TC03: Validate that the 'No' radio button cannot be selected by the cursor."""
+        no_radio_button = web.find_element(By.CSS_SELECTOR, "input#noRadio")
+        cursor_style = no_radio_button.value_of_css_property("cursor")
+
+        assert cursor_style == "not-allowed"
+
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/e2e/Elements/test_Elements_Text_Box.py
+++ b/tests/e2e/Elements/test_Elements_Text_Box.py
@@ -1,0 +1,171 @@
+from tests.e2e.utils.imports import *
+
+
+class TestElementsTextBox:
+
+    @pytest.fixture
+    def web(self):
+        """Precondition: Open the "demoqa" page and wait for it to load."""
+        driver = Chrome()
+        driver.get('https://demoqa.com/text-box')
+        text_box_page = TextBoxPage(driver)
+        text_box_page.wait_for_displaying()
+        yield driver
+        driver.quit()
+
+    def test_should_display_inserted_information_after_submit(self, web: WebDriver):
+        """TC01: Validate that when all inputs are filled correctly and "Submit" is pressed, the inserted information is displayed."""
+        text_box_page = TextBoxPage(web)
+        
+        # Inputs
+        user_name = "My Name"
+        is_email_valid = "emails@example.com"
+        current_address = "Mi direccion 23/23"
+        permanent_address = "Mi direccion 23/23"
+        # Interaction
+        text_box_page.enter_user_name(user_name)
+        text_box_page.enter_email(is_email_valid)
+        text_box_page.enter_current_address(current_address)
+        text_box_page.enter_permanent_address(permanent_address)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        # Validation
+        displayed_data = text_box_page.get_displayed_information()
+        assert displayed_data["name"] == f"Name:{user_name}"
+        assert displayed_data["email"] == f"Email:{is_email_valid}"
+        assert displayed_data["current_address"] == f"Current Address :{current_address}"
+        assert displayed_data["permanent_address"] == f"Permananet Address :{permanent_address}"
+
+    def test_no_elements_shown_when_inputs_are_empty(self, web: WebDriver):
+        """TC02: Validate that NOTHING is displayed when all inputs are left empty and "Submit" is pressed."""
+        text_box_page = TextBoxPage(web)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        
+        stored_name = web.find_elements(By.ID, "name")
+        stored_email = web.find_elements(By.ID, "email")
+        stored_current_address = web.find_elements(By.CSS_SELECTOR, "p#currentAddress")
+        stored_permanent_address = web.find_elements(By.CSS_SELECTOR, "p#permanentAddress")
+        
+        assert len(stored_name) == 0
+        assert len(stored_email) == 0
+        assert len(stored_current_address) == 0
+        assert len(stored_permanent_address) == 0
+        
+    def test_email_field_displays_error_for_invalid_email_without_at(self, web: WebDriver):
+        """TC03: Validate that an email without "@" is NOT accepted in the Email field and a red border is displayed."""
+        text_box_page = TextBoxPage(web)
+        # Inputs
+        user_name = "My Name"
+        is_email_invalid = "emailsexample.com"
+        current_address = "Mi direccion 23/23"
+        permanent_address = "Mi direccion 23/23"
+        # Interaction
+        text_box_page.enter_user_name(user_name)
+        text_box_page.enter_email(is_email_invalid )
+        text_box_page.enter_current_address(current_address)
+        text_box_page.enter_permanent_address(permanent_address)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        # Validation: Verify the border color of the email field
+        email_field = web.find_element(By.CSS_SELECTOR, "input#userEmail.mr-sm-2.field-error.form-control")
+        for _ in range(10): 
+            border_color = email_field.value_of_css_property("border-color")  # Obtiene el color del borde
+            if border_color == "rgb(255, 0, 0)":  # Si el color es rojo, salimos del bucle
+                break
+            time.sleep(0.2) 
+        assert "rgb(255, 0, 0)" == border_color or "#ff0000" == border_color
+        
+    def test_email_field_displays_error_for_invalid_email_without_alphanumeric_before_at(self, web: WebDriver):
+        """TC04: Validate that an email without an alphanumeric character before "@" is NOT accepted and a red border is displayed."""
+        text_box_page = TextBoxPage(web)
+        # Inputs
+        user_name = "My Name"
+        is_email_invalid = "@example.com"
+        current_address = "Mi direccion 23/23"
+        permanent_address = "Mi direccion 23/23"
+        # Interaction
+        text_box_page.enter_user_name(user_name)
+        text_box_page.enter_email(is_email_invalid )
+        text_box_page.enter_current_address(current_address)
+        text_box_page.enter_permanent_address(permanent_address)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        # Validation: Verify the border color of the email field
+        email_field = web.find_element(By.CSS_SELECTOR, "input#userEmail.mr-sm-2.field-error.form-control")
+        for _ in range(10): 
+            border_color = email_field.value_of_css_property("border-color")  # Obtiene el color del borde
+            if border_color == "rgb(255, 0, 0)":  # Si el color es rojo, salimos del bucle
+                break
+            time.sleep(0.2) 
+        assert "rgb(255, 0, 0)" == border_color or "#ff0000" == border_color
+        
+    def test_email_field_displays_error_for_invalid_email_without_alphanumeric_after_at(self, web: WebDriver):
+        """TC05: Validate that an email without an alphanumeric character after "@" is NOT accepted and a red border is displayed."""
+        text_box_page = TextBoxPage(web)
+        # Inputs
+        user_name = "My Name"
+        is_email_invalid = "email@.com"
+        current_address = "Mi direccion 23/23"
+        permanent_address = "Mi direccion 23/23"
+        # Interaction
+        text_box_page.enter_user_name(user_name)
+        text_box_page.enter_email(is_email_invalid )
+        text_box_page.enter_current_address(current_address)
+        text_box_page.enter_permanent_address(permanent_address)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        # Validation: Verify the border color of the email field
+        email_field = web.find_element(By.CSS_SELECTOR, "input#userEmail.mr-sm-2.field-error.form-control")
+        for _ in range(10): 
+            border_color = email_field.value_of_css_property("border-color")  # Obtiene el color del borde
+            if border_color == "rgb(255, 0, 0)":  # Si el color es rojo, salimos del bucle
+                break
+            time.sleep(0.2) 
+        assert "rgb(255, 0, 0)" == border_color or "#ff0000" == border_color        
+
+    def test_email_field_displays_error_for_invalid_email_without_dot_after_at(self, web: WebDriver):
+        """TC06: Validate that an email without a "." after "@" is NOT accepted and a red border is displayed."""
+        text_box_page = TextBoxPage(web)
+        # Inputs
+        user_name = "My Name"
+        is_email_invalid = "email@examplecom"
+        current_address = "Mi direccion 23/23"
+        permanent_address = "Mi direccion 23/23"
+        # Interaction
+        text_box_page.enter_user_name(user_name)
+        text_box_page.enter_email(is_email_invalid )
+        text_box_page.enter_current_address(current_address)
+        text_box_page.enter_permanent_address(permanent_address)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        # Validation: Verify the border color of the email field
+        email_field = web.find_element(By.CSS_SELECTOR, "input#userEmail.mr-sm-2.field-error.form-control")
+        for _ in range(10): 
+            border_color = email_field.value_of_css_property("border-color")  # Obtiene el color del borde
+            if border_color == "rgb(255, 0, 0)":  # Si el color es rojo, salimos del bucle
+                break
+            time.sleep(0.2) 
+        assert "rgb(255, 0, 0)" == border_color or "#ff0000" == border_color        
+
+    def test_email_field_displays_error_for_invalid_email_without_two_characters_after_dot(self, web: WebDriver):
+        """TC07: Validate that an email without two characters after "." is NOT accepted and a red border is displayed."""
+        text_box_page = TextBoxPage(web)
+        # Inputs
+        user_name = "My Name"
+        is_email_invalid = "email@example.c"
+        current_address = "Mi direccion 23/23"
+        permanent_address = "Mi direccion 23/23"
+        # Interaction
+        text_box_page.enter_user_name(user_name)
+        text_box_page.enter_email(is_email_invalid )
+        text_box_page.enter_current_address(current_address)
+        text_box_page.enter_permanent_address(permanent_address)
+        web.execute_script("arguments[0].scrollIntoView(true);", text_box_page.submit_button())
+        text_box_page.click_submit_button()
+        # Validation: Verify the border color of the email field
+        field_state = text_box_page.email_input().get_attribute("class")
+        assert "field-error" in field_state
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/e2e/pages/page.py
+++ b/tests/e2e/pages/page.py
@@ -1,0 +1,17 @@
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webelement import WebElement
+
+
+#Super Page!!!
+
+class SuperPage:
+    def __init__(self, driver: WebDriver):
+        self.web = driver
+        
+    def wait_for_element(self, element:WebElement, seconds=5):
+        is_visible = lambda: element.is_displayed()
+        WebDriverWait(self.web, seconds).until(lambda web: is_visible(), message="El elemento no aparece en el tiempo esperado.")
+        

--- a/tests/e2e/pages/textbox_page.py
+++ b/tests/e2e/pages/textbox_page.py
@@ -1,0 +1,42 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.common.by import By
+from tests.e2e.pages.page import SuperPage
+
+class TextBoxPage(SuperPage):
+    def __init__(self, driver: WebDriver):
+        super().__init__(driver)
+        
+        # Usamos lambda para retrasar la búsqueda de los elementos hasta que realmente se necesiten.
+        self.user_name_input = lambda: self.web.find_element(By.CSS_SELECTOR, "input#userName")
+        self.email_input = lambda: self.web.find_element(By.CSS_SELECTOR, "input#userEmail")
+        self.current_address_input = lambda: self.web.find_element(By.CSS_SELECTOR, "textarea#currentAddress")
+        self.permanent_address_input = lambda: self.web.find_element(By.CSS_SELECTOR, "textarea#permanentAddress")
+        self.submit_button = lambda: self.web.find_element(By.CSS_SELECTOR, "button#submit")
+        
+    def wait_for_displaying(self):
+        assert "text-box" in self.web.current_url
+        page_button = self.web.find_element(By.CSS_SELECTOR, ".btn-primary")
+        self.wait_for_element(page_button)
+        
+    def enter_user_name(self, value: str):
+        self.user_name_input().send_keys(value)
+        
+    def enter_email(self, value: str):
+        self.email_input().send_keys(value)
+        
+    def enter_current_address(self, value: str):
+        self.current_address_input().send_keys(value)
+        
+    def enter_permanent_address(self, value: str):
+        self.permanent_address_input().send_keys(value)
+        
+    def click_submit_button(self):
+        self.submit_button().click()
+        
+    def get_displayed_information(self):
+        return {
+            "name": self.web.find_element(By.ID, "name").text,
+            "email": self.web.find_element(By.ID, "email").text,
+            "current_address": self.web.find_element(By.CSS_SELECTOR, "p#currentAddress").text,
+            "permanent_address": self.web.find_element(By.CSS_SELECTOR, "p#permanentAddress").text,
+        }

--- a/tests/e2e/utils/imports.py
+++ b/tests/e2e/utils/imports.py
@@ -1,4 +1,5 @@
-#Mis imports para las pruebas
+#Mis imports
+import time
 import pytest
 from selenium.webdriver import Chrome
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -6,3 +7,4 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
+from tests.e2e.pages.textbox_page import TextBoxPage


### PR DESCRIPTION
# Resumen de cambios

- Se añadieron tres casos de prueba E2E para validar mensajes tras seleccionar botones de opción (radio buttons) en la página demo.
- Pruebas para asegurar que los botones "Yes" e "Impressive" muestran los mensajes correctos, y que el botón "No" no puede ser seleccionado.
- Uso de Selenium con pytest para automatizar las pruebas.

# Resultados de pruebas 
![image](https://github.com/user-attachments/assets/bfa2a5a1-d00b-48d3-98bf-964958f8109a)

# Observaciones

- Las pruebas aseguran que los mensajes correctos se muestren tras seleccionar los botones de opción y que el botón "No" no sea seleccionable.
- Se mantiene la estructura del proyecto y se implementa la limpieza del entorno al cerrar el navegador al finalizar cada prueba.
